### PR TITLE
Readme improvements

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -24,14 +24,18 @@ Hosts can distribute FAIR to their customers via:
 
 Hosts may also configure their own repository mirrors and toggle settings like Gravatar use. With minimal setup and modular architecture, the FAIR system ensures technical independence, resilience, and long-term sustainability for WordPress deployments.
 
-### 📚 Learn about the project
+### 📚 Learn more about the project
+
+* [Our roadmap](https://github.com/orgs/fairpm/discussions/24) - See what we're up to for the next releases.
+* [FAQ](https://github.com/fairpm/tsc/blob/main/faqs/README.md) - Our FAQ. Because sometimes, starting with someone else's questions is easiest.
+
+### 🛠️️ Learn about getting involved with the project
 
 * [Getting Started Guide](https://github.com/fairpm/tsc/blob/main/getting-started.md) - Start here to learn about getting involved with the project!
 * [Contributing Guide](https://github.com/fairpm/tsc/blob/main/contributing.md) - Learn about the project structure, Technical Steering Committee (TSC), working groups and the governance process.
 * [Technical Steering Committee Charter](https://github.com/fairpm/tsc/blob/main/charter.md) - Our charter outlines our governance model.
 * [Code of Conduct](https://github.com/fairpm/tsc/blob/main/code-of-conduct.md) - Our code of conduct outlines how we keep our open source project welcoming and safe.
 * [Working Groups](https://github.com/fairpm/tsc/tree/main/working-groups) - Learn about our current project focuses.
-* [FAQ](https://github.com/fairpm/tsc/blob/main/faqs/README.md) - Our FAQ. Because sometimes, starting with someone else's questions is easiest.
 
 ### ✏️ Working Groups Overview
 


### PR DESCRIPTION
* Split "learn more about the project itself" and "getting involved with".
* Add a link to the roadmap to the former section and also move the FAQ to it.
